### PR TITLE
Fix escaping for wizard checklist styles

### DIFF
--- a/theme.py
+++ b/theme.py
@@ -354,18 +354,18 @@ button:focus-visible {{
     font-size: calc(0.92rem * var(--base-font-scale));
 }}
 
-.wizard-checklist {
+.wizard-checklist {{
     display: grid;
     gap: 0.35rem;
     padding: 0.4rem 0;
-}
+}}
 
-.wizard-checklist__item {
+.wizard-checklist__item {{
     display: flex;
     align-items: center;
     gap: 0.4rem;
     font-size: calc(0.92rem * var(--base-font-scale));
-}
+}}
 
 .visually-hidden {{
     position: absolute !important;


### PR DESCRIPTION
## Summary
- ensure the wizard checklist CSS rules use escaped braces in the theme template so `str.format` substitution succeeds without KeyErrors

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'ui')*

------
https://chatgpt.com/codex/tasks/task_e_68d0db59c32c832385e8899572653eec