### PR TITLE
Add tax breakdown preview and cash flow table for tax planning

### DIFF
--- a/calc/cf.py
+++ b/calc/cf.py
@@ -114,7 +114,8 @@ def generate_cash_flow(
 
     ordinary_income = Decimal(pl_amounts.get("ORD", Decimal("0")))
     depreciation = Decimal(pl_amounts.get("OPEX_DEP", Decimal("0")))
-    taxes = tax.effective_tax(ordinary_income)
+    income_tax_breakdown = tax.income_tax_components(ordinary_income)
+    taxes = income_tax_breakdown["total"]
 
     net_income = ordinary_income - taxes
     operating_cf = ordinary_income + depreciation - taxes
@@ -153,6 +154,7 @@ def generate_cash_flow(
         "税引後利益": net_income,
         "減価償却": depreciation,
         "営業キャッシュフロー（利払前）": operating_cf + interest_total_first_year,
+        "税金内訳": income_tax_breakdown,
         "loan_schedule": loan_schedule,
         "capex_schedule": capex_schedule,
         "investment_metrics": {

--- a/tests/test_cash_flow.py
+++ b/tests/test_cash_flow.py
@@ -28,7 +28,7 @@ class CashFlowGenerationTests(unittest.TestCase):
                 )
             ]
         )
-        tax_policy = TaxPolicy(corporate_tax_rate=Decimal("0.30"))
+        tax_policy = TaxPolicy(corporate_tax_rate=Decimal("0.30"), business_tax_rate=Decimal("0.0"))
 
         pl_amounts = {"ORD": Decimal("50000"), "OPEX_DEP": Decimal("20000")}
 
@@ -56,6 +56,10 @@ class CashFlowGenerationTests(unittest.TestCase):
         self.assertIsNotNone(metrics.get("payback_period_years"))
         monthly_cash_flows = metrics.get("monthly_cash_flows", [])
         self.assertEqual(len(monthly_cash_flows), 120)
+
+        tax_breakdown = result.get("税金内訳", {})
+        self.assertEqual(Decimal("15000"), tax_breakdown.get("corporate", Decimal("0")))
+        self.assertEqual(Decimal("0"), tax_breakdown.get("business", Decimal("0")))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -49,6 +49,7 @@ class LoadFinanceBundleTests(unittest.TestCase):
             },
             "tax": {
                 "corporate_tax_rate": "0.30",
+                "business_tax_rate": "0.05",
                 "consumption_tax_rate": "0.10",
                 "dividend_payout_ratio": "0.0",
             },


### PR DESCRIPTION
## Summary
- extend the tax policy model with business tax support, consumption-tax utilities, and surface the tax breakdown in cash-flow calculations
- enhance Step 5 of the input wizard with a business tax input, annual tax estimate table, and monthly cash-flow preview that highlights potential shortfalls
- align the analysis page and tests with the richer tax handling

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d25bc46ecc8323a65e27bf2e411963