### PR TITLE
Add financial timeseries inputs and trend analytics

### DIFF
--- a/state.py
+++ b/state.py
@@ -93,6 +93,11 @@ STATE_SPECS: Dict[str, StateSpec] = {
         dict,
         "Fermi推定の学習履歴",
     ),
+    "financial_timeseries": StateSpec(
+        lambda: {"records": [], "base_year": None},
+        dict,
+        "多年度の財務指標データ",
+    ),
     "tutorial_mode": StateSpec(lambda: True, bool, "チュートリアルモードの有効/無効"),
     "tutorial_shown_steps": StateSpec(lambda: set(), set, "チュートリアル表示済みステップ"),
     "cost_range_profiles": StateSpec(dict, dict, "コスト推定レンジの保存領域"),


### PR DESCRIPTION
## Summary
- add financial timeseries session state with defaults for multi-year KPI entry
- extend the Inputs wizard to capture 3-year actual and 5-year plan figures plus persist them in snapshots
- surface automated break-even, EBITDA/FCF/ROA calculations, monthly charts, and regression-based trend metrics on a new analysis tab

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2739901fc8323ac2bf89048f84708