### PR TITLE
Add SWOT and PEST analysis workflows

### DIFF
--- a/state.py
+++ b/state.py
@@ -98,6 +98,11 @@ STATE_SPECS: Dict[str, StateSpec] = {
         dict,
         "多年度の財務指標データ",
     ),
+    "strategic_analysis": StateSpec(
+        lambda: {"swot": [], "pest": []},
+        dict,
+        "SWOT・PEST分析の入力データ",
+    ),
     "tutorial_mode": StateSpec(lambda: True, bool, "チュートリアルモードの有効/無効"),
     "tutorial_shown_steps": StateSpec(lambda: set(), set, "チュートリアル表示済みステップ"),
     "cost_range_profiles": StateSpec(dict, dict, "コスト推定レンジの保存領域"),


### PR DESCRIPTION
## Summary
- add SWOT・PEST editors and persistence to the business model input step so qualitative factors can be captured alongside numeric plans
- introduce a strategic analysis tab that visualises SWOT quadrants, PEST summaries, and quantitative cross insights driven by the captured data

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d278d3b508832395aa23d808609919