### PR TITLE
Revise UI palette, typography, and iconography

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ from views import render_home_page
 
 st.set_page_config(
     page_title="経営計画スタジオ",
-    page_icon="📊",
+    page_icon="▥",
     layout="wide",
 )
 

--- a/pages/00_Home.py
+++ b/pages/00_Home.py
@@ -7,7 +7,7 @@ from views import render_home_page
 
 st.set_page_config(
     page_title="経営計画スタジオ｜概要",
-    page_icon="📊",
+    page_icon="▥",
     layout="wide",
 )
 

--- a/pages/10_Inputs.py
+++ b/pages/10_Inputs.py
@@ -49,7 +49,7 @@ from ui.fermi import FERMI_SEASONAL_PATTERNS, compute_fermi_estimate
 
 st.set_page_config(
     page_title="経営計画スタジオ｜Inputs",
-    page_icon="🧾",
+    page_icon="✎",
     layout="wide",
 )
 
@@ -736,7 +736,7 @@ def _maybe_show_tutorial(step_id: str, message: str) -> None:
         shown = set()
     if step_id in shown:
         return
-    st.toast(message, icon="💡")
+    st.toast(message, icon="✦")
     shown.add(step_id)
     st.session_state["tutorial_shown_steps"] = shown
 
@@ -856,14 +856,14 @@ def _render_fermi_wizard(sales_df: pd.DataFrame, unit: str) -> None:
     history: List[Dict[str, object]] = learning_state.get("history", [])
     expand_default = st.session_state.get("tutorial_mode", False) and not history
 
-    with st.expander("🧮 Fermi推定ウィザード", expanded=expand_default):
+    with st.expander("算 Fermi推定ウィザード", expanded=expand_default):
         st.markdown(
             "日次の来店数・客単価・営業日数を入力すると、年間売上の中央値/最低/最高レンジを推定します。"
             " 最小値・中央値・最大値で売上レンジを把握し、シナリオ比較に活用しましょう。"
             " 学習済みの実績データがあれば中央値を自動補正します。"
         )
         render_callout(
-            icon="📈",
+            icon="指",
             title="レンジ入力の目的",
             body="最小値は悲観ケース、中央値は標準ケース、最大値は成長ケースとして設定し、年間売上の幅やシナリオ分析に活用しましょう。推定結果はテンプレートの年間売上レンジにも反映できます。",
         )
@@ -1050,7 +1050,7 @@ def _render_fermi_wizard(sales_df: pd.DataFrame, unit: str) -> None:
             if st.button("推定結果をテンプレートに適用", type="primary", key="fermi_apply_button"):
                 updated_df = _apply_fermi_result(sales_df)
                 st.session_state[SALES_TEMPLATE_STATE_KEY] = updated_df
-                st.toast("Fermi推定を売上テンプレートに反映しました。", icon="✅")
+                st.toast("Fermi推定を売上テンプレートに反映しました。", icon="✔")
                 st.experimental_rerun()
 
         if history:
@@ -1476,7 +1476,7 @@ def _render_sales_guide_panel() -> None:
     st.markdown(
         """
         <div class="guide-panel" style="background-color:rgba(240,248,255,0.6);padding:1rem;border-radius:0.75rem;">
-            <h4 style="margin-top:0;">💡 入力ガイド</h4>
+            <h4 style="margin-top:0;">✦ 入力ガイド</h4>
             <ul style="padding-left:1.2rem;">
                 <li title="例示による入力イメージ">チャネル×商品×月の例：<strong>オンライン販売 10万円</strong>、<strong>店舗販売 5万円</strong>のように具体的な数字から積み上げると精度が高まります。</li>
                 <li title="売上＝客数×客単価×購入頻度">売上は <strong>客数×客単価×購入頻度</strong> に分解すると改善ポイントが見えます。</li>
@@ -1627,7 +1627,7 @@ def _apply_industry_template(template_key: str, unit_factor: Decimal) -> None:
     )
     metric_state[template_key] = template.custom_metrics
     st.session_state["industry_custom_metrics"] = metric_state
-    st.toast(f"{template.label}のテンプレートを適用しました。", icon="🧩")
+    st.toast(f"{template.label}のテンプレートを適用しました。", icon="□")
 
 
 def _capex_dataframe(data: Dict) -> pd.DataFrame:
@@ -2048,10 +2048,10 @@ completion_flags = _calculate_completion_flags(
     loan_df=loan_editor_snapshot,
 )
 
-st.title("🧾 データ入力ハブ")
+st.title("データ入力ハブ")
 st.caption("ウィザード形式で売上から投資までを順番に整理します。保存すると全ページに反映されます。")
 
-st.sidebar.title("📘 ヘルプセンター")
+st.sidebar.title("ヘルプセンター")
 with st.sidebar.expander("よくある質問 (FAQ)", expanded=False):
     st.markdown(
         """
@@ -2093,9 +2093,9 @@ if current_step == "context":
             saved_label = saved_dt.strftime("%Y-%m-%d %H:%M:%S")
         except ValueError:
             saved_label = str(last_saved_iso)
-        st.caption(f"💾 入力内容は自動保存されます（最終保存: {saved_label}）")
+        st.caption(f"保存ステータス: 入力内容は自動保存されます（最終保存: {saved_label}）")
     else:
-        st.caption("💾 入力内容は自動保存されます。")
+        st.caption("保存ステータス: 入力内容は自動保存されます。")
 
     three_c_cols = st.columns(3)
     with three_c_cols[0]:
@@ -2627,7 +2627,7 @@ elif current_step == "sales":
                 st.session_state[SALES_PRODUCT_COUNTER_KEY] = next_product_idx + 1
                 updated = pd.concat([sales_df, pd.DataFrame([new_row])], ignore_index=True)
                 st.session_state[SALES_TEMPLATE_STATE_KEY] = _standardize_sales_df(updated)
-                st.toast("新しいチャネル行を追加しました。", icon="➕")
+                st.toast("新しいチャネル行を追加しました。", icon="＋")
 
         channel_options = [str(ch) for ch in sales_df["チャネル"].tolist() if str(ch).strip()]
         if not channel_options:
@@ -2659,7 +2659,7 @@ elif current_step == "sales":
                 st.session_state[SALES_PRODUCT_COUNTER_KEY] = next_product_idx + 1
                 updated = pd.concat([sales_df, pd.DataFrame([new_row])], ignore_index=True)
                 st.session_state[SALES_TEMPLATE_STATE_KEY] = _standardize_sales_df(updated)
-                st.toast("選択したチャネルに商品行を追加しました。", icon="🆕")
+                st.toast("選択したチャネルに商品行を追加しました。", icon="新")
 
         sales_df = st.session_state[SALES_TEMPLATE_STATE_KEY]
         month_columns_config = {
@@ -2912,13 +2912,13 @@ elif current_step == "sales":
                                 ignore_index=True,
                             )
                             st.session_state[SALES_TEMPLATE_STATE_KEY] = _standardize_sales_df(updated)
-                            st.toast("外部データを売上テンプレートに追加しました。", icon="📥")
+                            st.toast("外部データを売上テンプレートに追加しました。", icon="収")
                         if apply_to_plan and target_metric == "固定費" and selected_fixed_code:
                             monthly_average = Decimal(str(total_amount)) / Decimal(len(MONTH_SEQUENCE))
                             st.session_state[f"fixed_cost_{selected_fixed_code}"] = float(
                                 monthly_average / (unit_factor or Decimal("1"))
                             )
-                            st.toast("固定費を実績平均で更新しました。", icon="💰")
+                            st.toast("固定費を実績平均で更新しました。", icon="資")
                         st.success("実績データを保存しました。分析ページで予実差異が表示されます。")
             elif uploaded_external is not None:
                 st.warning("読み込めるデータがありません。サンプル行を確認してください。")
@@ -3092,7 +3092,7 @@ elif current_step == "costs":
         st.info("コスト項目が0のため、粗利率チャートを描画できるデータがありません。")
 
     cost_range_state: Dict[str, Dict[str, float]] = st.session_state.get(COST_RANGE_STATE_KEY, {})
-    with st.expander("🔀 レンジ入力 (原価・費用の幅)", expanded=False):
+    with st.expander("調 レンジ入力 (原価・費用の幅)", expanded=False):
         st.caption("最小・中央値・最大の3点を入力すると、分析ページで感度レンジを参照できます。")
 
         variable_rows = []
@@ -3455,12 +3455,12 @@ elif current_step == "tax":
     metric_cols = st.columns(2)
     with metric_cols[0]:
         st.markdown(
-            f"<div class='metric-card' title='年間のチャネル×商品売上の合計額です。'>📊 <strong>売上合計</strong><br/><span style='font-size:1.4rem;'>{format_amount_with_unit(total_sales, unit)}</span></div>",
+            f"<div class='metric-card' title='年間のチャネル×商品売上の合計額です。'>¥ <strong>売上合計</strong><br/><span style='font-size:1.4rem;'>{format_amount_with_unit(total_sales, unit)}</span></div>",
             unsafe_allow_html=True,
         )
     with metric_cols[1]:
         st.markdown(
-            f"<div class='metric-card' title='粗利益率＝(売上−売上原価)÷売上。製造業では30%を超えると優良とされます。'>📊 <strong>平均原価率</strong><br/><span style='font-size:1.4rem;'>{format_ratio(avg_ratio)}</span></div>",
+            f"<div class='metric-card' title='粗利益率＝(売上−売上原価)÷売上。製造業では30%を超えると優良とされます。'>↗ <strong>平均原価率</strong><br/><span style='font-size:1.4rem;'>{format_ratio(avg_ratio)}</span></div>",
             unsafe_allow_html=True,
         )
 
@@ -3752,7 +3752,7 @@ elif current_step == "tax":
         ):
             if preview_issues:
                 st.session_state["finance_validation_errors"] = preview_issues
-                st.toast("入力にエラーがあります。赤枠の項目を修正してください。", icon="❌")
+                st.toast("入力にエラーがあります。赤枠の項目を修正してください。", icon="✖")
             else:
                 st.session_state["finance_validation_errors"] = []
                 st.session_state[SALES_TEMPLATE_STATE_KEY] = sales_df
@@ -3765,14 +3765,14 @@ elif current_step == "tax":
                         "loans": preview_bundle.loans,
                         "tax": preview_bundle.tax,
                     }
-                st.toast("財務データを保存しました。", icon="✅")
+                st.toast("財務データを保存しました。", icon="✔")
 
     st.divider()
     st.subheader("クラウド保存とバージョン管理")
 
     if not auth.is_authenticated():
         render_callout(
-            icon="🔐",
+            icon="▣",
             title="アカウントにログインするとクラウド保存できます",
             body="ヘッダー右上のログインからアカウントを作成し、計画をクラウドに保存してバージョン管理しましょう。",
             tone="caution",
@@ -3807,7 +3807,7 @@ elif current_step == "tax":
                         )
                         st.success(
                             f"{summary.plan_name} をバージョン v{summary.version} として保存しました。",
-                            icon="✅",
+                            icon="✔",
                         )
                         st.session_state["plan_save_note"] = ""
                     except AuthError as exc:
@@ -3849,7 +3849,7 @@ elif current_step == "tax":
                         elif _hydrate_snapshot(payload):
                             st.toast(
                                 f"{selected_plan.name} v{selected_version.version} を読み込みました。",
-                                icon="✅",
+                                icon="✔",
                             )
                             st.experimental_rerun()
                 else:

--- a/pages/20_Analysis.py
+++ b/pages/20_Analysis.py
@@ -1164,7 +1164,7 @@ def build_dscr_timeseries(
 
 st.set_page_config(
     page_title="経営計画スタジオ｜Analysis",
-    page_icon="📈",
+    page_icon="▥",
     layout="wide",
 )
 
@@ -1356,7 +1356,7 @@ for idx, row in monthly_pl_df.iterrows():
 
 monthly_bs_df = pd.DataFrame(monthly_bs_rows)
 
-st.title("📈 KPI・損益分析")
+st.title("KPI・損益分析")
 st.caption(f"FY{fiscal_year} / 表示単位: {unit} / FTE: {fte}")
 
 kpi_tab, be_tab, cash_tab, trend_tab, strategy_tab = st.tabs(
@@ -1390,14 +1390,14 @@ with kpi_tab:
             "label": "売上高",
             "value": Decimal(amounts.get("REV", Decimal("0"))),
             "formatter": _amount_formatter,
-            "icon": "💴",
+            "icon": "売",
             "description": "年度売上の合計値",
         },
         "gross": {
             "label": "粗利",
             "value": Decimal(amounts.get("GROSS", Decimal("0"))),
             "formatter": _amount_formatter,
-            "icon": "🧮",
+            "icon": "粗",
             "description": "売上から原価を差し引いた利益",
             "tone_fn": lambda v: "negative" if v < Decimal("0") else "positive" if v > Decimal("0") else "neutral",
         },
@@ -1405,7 +1405,7 @@ with kpi_tab:
             "label": "営業利益",
             "value": Decimal(amounts.get("OP", Decimal("0"))),
             "formatter": _amount_formatter,
-            "icon": "🏭",
+            "icon": "営",
             "description": "本業による利益水準",
             "tone_fn": lambda v: "negative" if v < Decimal("0") else "positive" if v > Decimal("0") else "neutral",
         },
@@ -1413,7 +1413,7 @@ with kpi_tab:
             "label": "経常利益",
             "value": Decimal(amounts.get("ORD", Decimal("0"))),
             "formatter": _amount_formatter,
-            "icon": "📊",
+            "icon": "常",
             "description": "営業外収支を含む利益",
             "tone_fn": lambda v: "negative" if v < Decimal("0") else "positive" if v > Decimal("0") else "neutral",
         },
@@ -1421,7 +1421,7 @@ with kpi_tab:
             "label": "営業キャッシュフロー",
             "value": Decimal(cf_data.get("営業キャッシュフロー", Decimal("0"))),
             "formatter": _amount_formatter,
-            "icon": "💡",
+            "icon": "現",
             "description": "営業活動で得たキャッシュ",
             "tone_fn": lambda v: "negative" if v < Decimal("0") else "positive" if v > Decimal("0") else "neutral",
         },
@@ -1429,7 +1429,7 @@ with kpi_tab:
             "label": "フリーCF",
             "value": Decimal(cf_data.get("キャッシュ増減", Decimal("0"))),
             "formatter": _amount_formatter,
-            "icon": "🪙",
+            "icon": "余",
             "description": "投資・財務CF後に残る現金",
             "tone_fn": lambda v: "negative" if v < Decimal("0") else "positive" if v > Decimal("0") else "neutral",
         },
@@ -1437,7 +1437,7 @@ with kpi_tab:
             "label": "税引後利益",
             "value": Decimal(cf_data.get("税引後利益", Decimal("0"))),
             "formatter": _amount_formatter,
-            "icon": "✅",
+            "icon": "純",
             "description": "法人税控除後の純利益",
             "tone_fn": lambda v: "negative" if v < Decimal("0") else "positive" if v > Decimal("0") else "neutral",
         },
@@ -1445,7 +1445,7 @@ with kpi_tab:
             "label": "期末現金残高",
             "value": Decimal(cash_total),
             "formatter": _amount_formatter,
-            "icon": "💰",
+            "icon": "資",
             "description": "貸借対照表上の現金・預金残高",
             "tone_fn": lambda v: "negative" if v < Decimal("0") else "positive" if v > Decimal("0") else "neutral",
         },
@@ -1453,7 +1453,7 @@ with kpi_tab:
             "label": "自己資本比率",
             "value": Decimal(bs_metrics.get("equity_ratio", Decimal("NaN"))),
             "formatter": format_ratio,
-            "icon": "🛡️",
+            "icon": "盾",
             "description": "総資産に対する自己資本の割合",
             "tone_fn": lambda v: _tone_threshold(v, positive=Decimal("0.4"), caution=Decimal("0.2")),
         },
@@ -1461,7 +1461,7 @@ with kpi_tab:
             "label": "ROE",
             "value": Decimal(bs_metrics.get("roe", Decimal("NaN"))),
             "formatter": format_ratio,
-            "icon": "📐",
+            "icon": "益",
             "description": "自己資本に対する利益率",
             "tone_fn": lambda v: _tone_threshold(v, positive=Decimal("0.1"), caution=Decimal("0.0")),
         },
@@ -1469,28 +1469,28 @@ with kpi_tab:
             "label": "ネット運転資本",
             "value": Decimal(bs_metrics.get("working_capital", Decimal("0"))),
             "formatter": _yen_formatter,
-            "icon": "🔄",
+            "icon": "循",
             "description": "売掛金・棚卸資産と買掛金の差分",
         },
         "customer_count": {
             "label": "年間想定顧客数",
             "value": Decimal(sales_summary.get("total_customers", Decimal("0"))),
             "formatter": _count_formatter,
-            "icon": "🙋",
+            "icon": "顧",
             "description": "年間に購買する顧客数の見込み",
         },
         "avg_unit_price": {
             "label": "平均客単価",
             "value": Decimal(sales_summary.get("avg_unit_price", Decimal("0"))),
             "formatter": _yen_formatter,
-            "icon": "🏷️",
+            "icon": "単",
             "description": "取引1件当たりの平均売上",
         },
         "avg_frequency": {
             "label": "平均購入頻度/月",
             "value": Decimal(sales_summary.get("avg_frequency", Decimal("0"))),
             "formatter": _frequency_formatter,
-            "icon": "🔁",
+            "icon": "頻",
             "description": "顧客1人当たりの月間購買頻度",
         },
     }
@@ -1538,7 +1538,7 @@ with kpi_tab:
         )
         cards.append(
             MetricCard(
-                icon=str(cfg.get("icon", "📊")),
+                icon=str(cfg.get("icon", "指")),
                 label=str(cfg.get("label")),
                 value=str(formatted_value),
                 description=descriptor,
@@ -1808,7 +1808,7 @@ with kpi_tab:
 
     financial_cards = [
         MetricCard(
-            icon="📊",
+            icon="粗",
             label="粗利率",
             value=format_ratio(metrics.get("gross_margin")),
             description="粗利÷売上",
@@ -1817,7 +1817,7 @@ with kpi_tab:
             assistive_text="粗利率のカード。粗利÷売上で収益性を確認できます。",
         ),
         MetricCard(
-            icon="💼",
+            icon="営",
             label="営業利益率",
             value=format_ratio(metrics.get("op_margin")),
             description="営業利益÷売上",
@@ -1826,7 +1826,7 @@ with kpi_tab:
             assistive_text="営業利益率のカード。販管費や投資負担を踏まえた収益性を示します。",
         ),
         MetricCard(
-            icon="📈",
+            icon="常",
             label="経常利益率",
             value=format_ratio(metrics.get("ord_margin")),
             description="経常利益÷売上",
@@ -1835,7 +1835,7 @@ with kpi_tab:
             assistive_text="経常利益率のカード。金融収支を含む最終的な収益力を示します。",
         ),
         MetricCard(
-            icon="🛡️",
+            icon="盾",
             label="自己資本比率",
             value=format_ratio(bs_metrics.get("equity_ratio", Decimal("NaN"))),
             description="総資産に対する自己資本",
@@ -1848,7 +1848,7 @@ with kpi_tab:
             assistive_text="自己資本比率のカード。財務の安定性を示し、40%超で健全域です。",
         ),
         MetricCard(
-            icon="🎯",
+            icon="益",
             label="ROE",
             value=format_ratio(bs_metrics.get("roe", Decimal("NaN"))),
             description="自己資本利益率",

--- a/pages/30_Scenarios.py
+++ b/pages/30_Scenarios.py
@@ -20,7 +20,7 @@ from ui.streamlit_compat import use_container_width_kwargs
 
 st.set_page_config(
     page_title="経営計画スタジオ｜Scenarios",
-    page_icon="🧮",
+    page_icon="∑",
     layout="wide",
 )
 
@@ -612,7 +612,7 @@ plan_cfg = plan_from_models(
     unit=unit,
 )
 
-st.title("🧮 シナリオ / 感度分析")
+st.title("シナリオ / 感度分析")
 
 scenario_tab, sensitivity_tab = st.tabs(["シナリオ比較", "感度・リスク分析"])
 
@@ -1110,7 +1110,7 @@ with sensitivity_tab:
         {key: value.copy() for key, value in DEFAULT_MC_CONFIG.items()},
     )
 
-    with st.expander("🎲 ランダム試行設定", expanded=False):
+    with st.expander("試行設定", expanded=False):
         st.caption("乱数分布と平均・標準偏差（％）を設定できます。")
         config_updates: Dict[str, Dict[str, float | str]] = {}
         for driver_key, driver_label in DRIVER_LABELS.items():
@@ -1161,7 +1161,7 @@ with sensitivity_tab:
             format_func=lambda x: METRIC_LABELS[x],
             key="mc_metric",
         )
-        run_button = st.button("🎯 モンテカルロを実行", key="mc_run_button")
+        run_button = st.button("モンテカルロを実行", key="mc_run_button")
 
     distribution_payload: Dict[str, Dict[str, float | str]] = {}
     current_mc_cfg = st.session_state.get("scenario_mc_config", {})

--- a/pages/40_Report.py
+++ b/pages/40_Report.py
@@ -35,7 +35,7 @@ from theme import THEME_COLORS, inject_theme
 
 st.set_page_config(
     page_title="経営計画スタジオ｜Report",
-    page_icon="📝",
+    page_icon="報",
     layout="wide",
 )
 
@@ -65,7 +65,7 @@ amounts = compute(plan_cfg)
 metrics = summarize_plan_metrics(amounts)
 cash_flow_data = generate_cash_flow(amounts, bundle.capex, bundle.loans, bundle.tax)
 
-st.title("📝 レポート出力")
+st.title("レポート出力")
 st.caption("主要指標とKPIのサマリーをPDF / Excel / Word形式でダウンロードできます。")
 
 SUPPORT_CONTACT = "support@keieiplan.jp"
@@ -560,19 +560,19 @@ with st.form("report_options_form"):
             }
         )
         st.session_state["report_options"] = report_options
-        st.success("レポート設定を更新しました。", icon="✅")
+        st.success("レポート設定を更新しました。", icon="✔")
 
 logo_upload = st.file_uploader("企業ロゴ (PNG/JPG/SVG)", type=["png", "jpg", "jpeg", "svg"], key="report_logo_upload")
 if logo_upload is not None:
     st.session_state["report_logo_bytes"] = logo_upload.getvalue()
     st.session_state["report_logo_name"] = logo_upload.name
-    st.toast("ロゴを読み込みました。", icon="🖼️")
+    st.toast("ロゴを読み込みました。", icon="図")
 
 seal_upload = st.file_uploader("印影画像 (PNG/JPG)", type=["png", "jpg", "jpeg"], key="report_seal_upload")
 if seal_upload is not None:
     st.session_state["report_seal_bytes"] = seal_upload.getvalue()
     st.session_state["report_seal_name"] = seal_upload.name
-    st.toast("印影を読み込みました。", icon="🖋️")
+    st.toast("印影を読み込みました。", icon="印")
 
 logo_bytes = (
     st.session_state.get("report_logo_bytes") if report_options.get("include_logo", True) else None
@@ -636,7 +636,7 @@ with pdf_tab:
         )
         if pdf_bytes is not None:
             st.download_button(
-                "📄 PDFダウンロード",
+                "［PDF］ダウンロード",
                 data=pdf_bytes,
                 file_name=f"plan_report_{fiscal_year}.pdf",
                 mime="application/pdf",
@@ -660,7 +660,7 @@ with excel_tab:
         )
         if excel_bytes is not None:
             st.download_button(
-                "📊 Excelダウンロード",
+                "［Excel］ダウンロード",
                 data=excel_bytes,
                 file_name=f"plan_report_{fiscal_year}.xlsx",
                 mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
@@ -689,7 +689,7 @@ with word_tab:
         )
         if word_bytes is not None:
             st.download_button(
-                "📝 Wordダウンロード",
+                "［Word］ダウンロード",
                 data=word_bytes,
                 file_name=f"plan_report_{fiscal_year}.docx",
                 mime="application/vnd.openxmlformats-officedocument.wordprocessingml.document",

--- a/pages/90_Settings.py
+++ b/pages/90_Settings.py
@@ -20,7 +20,7 @@ from ui.streamlit_compat import use_container_width_kwargs
 
 st.set_page_config(
     page_title="経営計画スタジオ｜Settings",
-    page_icon="⚙️",
+    page_icon="⚙",
     layout="wide",
 )
 
@@ -33,7 +33,7 @@ fte = float(settings_state.get("fte", 20.0))
 fiscal_year = int(settings_state.get("fiscal_year", 2025))
 language = str(settings_state.get("language", "ja"))
 
-st.title("⚙️ アプリ設定")
+st.title("アプリ設定")
 st.caption("表示単位や言語、既定値、データバックアップを管理できます。")
 
 unit_tab, language_tab, defaults_tab, backup_tab = st.tabs([
@@ -69,7 +69,7 @@ with defaults_tab:
             "tax": DEFAULT_TAX_POLICY.model_dump(),
         }
         st.session_state.pop("finance_models", None)
-        st.toast("既定値にリセットしました。", icon="✅")
+        st.toast("既定値にリセットしました。", icon="✔")
 
 if st.button("設定を保存", type="primary"):
         st.session_state["finance_settings"] = {
@@ -78,7 +78,7 @@ if st.button("設定を保存", type="primary"):
             "fte": float(fte),
             "fiscal_year": int(fiscal_year),
         }
-        st.toast("設定を保存しました。", icon="✅")
+        st.toast("設定を保存しました。", icon="✔")
 
 with backup_tab:
     st.subheader("バックアップとセキュリティ")
@@ -91,7 +91,7 @@ with backup_tab:
         backup_payload = auth.export_backup() or {}
         backup_bytes = json.dumps(backup_payload, ensure_ascii=False, indent=2).encode("utf-8")
         st.download_button(
-            "📥 JSONバックアップをダウンロード",
+            "［JSON］バックアップをダウンロード",
             data=backup_bytes,
             file_name="keieiplan_backup.json",
             mime="application/json",

--- a/theme.py
+++ b/theme.py
@@ -8,79 +8,79 @@ import streamlit as st
 from services.security import enforce_https
 
 THEME_COLORS: Dict[str, str] = {
-    "background": "#F7F9FB",
+    "background": "#F4F6FB",
     "surface": "#FFFFFF",
-    "surface_alt": "#E8F1FA",
-    "primary": "#1F4E79",
-    "primary_light": "#4F83B3",
-    "accent": "#F2C57C",
-    "positive": "#3A7D44",
-    "positive_strong": "#14532D",
-    "negative": "#C2410C",
-    "neutral": "#CBD5F5",
-    "text": "#1F2A37",
-    "text_subtle": "#4B5563",
-    "chart_blue": "#1f77b4",
-    "chart_orange": "#ff7f0e",
-    "chart_green": "#2ca02c",
-    "chart_purple": "#9467bd",
+    "surface_alt": "#E7ECF7",
+    "primary": "#1C6AD8",
+    "primary_light": "#5A8FE4",
+    "accent": "#0F2C4F",
+    "positive": "#1F6B54",
+    "positive_strong": "#0E3F2D",
+    "negative": "#8A3542",
+    "neutral": "#CBD4E4",
+    "text": "#0B1D33",
+    "text_subtle": "#4B5D75",
+    "chart_blue": "#1C6AD8",
+    "chart_orange": "#2E7ABF",
+    "chart_green": "#4F8ED8",
+    "chart_purple": "#7FA6E0",
 }
 
 DARK_THEME_COLORS: Dict[str, str] = {
-    "background": "#0F172A",
-    "surface": "#1E293B",
-    "surface_alt": "#24324D",
-    "primary": "#60A5FA",
-    "primary_light": "#93C5FD",
-    "accent": "#FBBF24",
-    "positive": "#34D399",
-    "positive_strong": "#059669",
-    "negative": "#F87171",
-    "neutral": "#64748B",
-    "text": "#F9FAFB",
-    "text_subtle": "#E2E8F0",
-    "chart_blue": "#60A5FA",
-    "chart_orange": "#F59E0B",
-    "chart_green": "#4ADE80",
-    "chart_purple": "#C4B5FD",
+    "background": "#061325",
+    "surface": "#0F1F35",
+    "surface_alt": "#172C4A",
+    "primary": "#4A8DE8",
+    "primary_light": "#74A5F1",
+    "accent": "#0A1E3A",
+    "positive": "#36B295",
+    "positive_strong": "#1C7A60",
+    "negative": "#D97582",
+    "neutral": "#42577A",
+    "text": "#E8EEF7",
+    "text_subtle": "#B8C4D9",
+    "chart_blue": "#4A8DE8",
+    "chart_orange": "#6FA4E8",
+    "chart_green": "#91B8F0",
+    "chart_purple": "#BACFF7",
 }
 
 COLOR_BLIND_COLORS: Dict[str, str] = {
-    "background": "#F8FAFC",
+    "background": "#F4F7FB",
     "surface": "#FFFFFF",
-    "surface_alt": "#E2E8F0",
-    "primary": "#205493",
-    "primary_light": "#2F74C8",
-    "accent": "#F0B429",
-    "positive": "#2E8540",
-    "positive_strong": "#1B512D",
-    "negative": "#B94700",
-    "neutral": "#CBD5E1",
-    "text": "#1F2933",
-    "text_subtle": "#52606D",
-    "chart_blue": "#0173B2",
-    "chart_orange": "#DE8F05",
-    "chart_green": "#029E73",
-    "chart_purple": "#CC78BC",
+    "surface_alt": "#E4EAF5",
+    "primary": "#1E63B6",
+    "primary_light": "#4D84CE",
+    "accent": "#0E2950",
+    "positive": "#226B93",
+    "positive_strong": "#134361",
+    "negative": "#8B4952",
+    "neutral": "#C7D2E3",
+    "text": "#0E223A",
+    "text_subtle": "#45546B",
+    "chart_blue": "#1E63B6",
+    "chart_orange": "#3F7FB6",
+    "chart_green": "#5F92C7",
+    "chart_purple": "#7FA6D8",
 }
 
 HIGH_CONTRAST_COLORS: Dict[str, str] = {
-    "background": "#0F172A",
-    "surface": "#111827",
-    "surface_alt": "#1F2937",
-    "primary": "#F97316",
-    "primary_light": "#FB923C",
-    "accent": "#FACC15",
-    "positive": "#22C55E",
-    "positive_strong": "#16A34A",
-    "negative": "#F87171",
-    "neutral": "#94A3B8",
-    "text": "#F9FAFB",
-    "text_subtle": "#E2E8F0",
-    "chart_blue": "#60A5FA",
-    "chart_orange": "#FDBA74",
-    "chart_green": "#86EFAC",
-    "chart_purple": "#C4B5FD",
+    "background": "#040A16",
+    "surface": "#0B1526",
+    "surface_alt": "#122036",
+    "primary": "#2F8BF5",
+    "primary_light": "#63A5FF",
+    "accent": "#FFFFFF",
+    "positive": "#3CD3A7",
+    "positive_strong": "#1E8A67",
+    "negative": "#FF848E",
+    "neutral": "#5F6E88",
+    "text": "#FFFFFF",
+    "text_subtle": "#D7E0F0",
+    "chart_blue": "#63A5FF",
+    "chart_orange": "#9FBFFB",
+    "chart_green": "#C4DBFF",
+    "chart_purple": "#E0EDFF",
 }
 
 CUSTOM_STYLE_TEMPLATE = """
@@ -111,15 +111,30 @@ html, body, [data-testid="stAppViewContainer"] {{
     color: var(--text-color);
     font-family: "Noto Sans JP", "Hiragino Sans", "Yu Gothic", sans-serif;
     font-size: calc(16px * var(--base-font-scale));
-    line-height: 1.6;
+    line-height: 1.62;
+    letter-spacing: 0.01em;
+}}
+
+h1, h2, h3, h4, h5, h6,
+.stMarkdown h1,
+.stMarkdown h2,
+.stMarkdown h3,
+.stMarkdown h4,
+.stMarkdown h5,
+.stMarkdown h6 {{
+    font-family: "Noto Serif JP", "Hiragino Mincho ProN", "Yu Mincho", "YuMincho", serif;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: var(--text-color);
 }}
 
 [data-testid="stSidebar"] {{
-    background: linear-gradient(180deg, var(--primary) 0%, var(--primary-light) 100%);
+    background: linear-gradient(180deg, rgba(15, 44, 79, 0.92) 0%, rgba(28, 106, 216, 0.88) 100%);
     color: #F7FAFC;
     width: calc(18rem - 9rem * var(--sidebar-compact));
     min-width: calc(16rem - 8rem * var(--sidebar-compact));
     transition: width 0.35s ease;
+    box-shadow: 12px 0 28px rgba(6, 19, 37, 0.2);
 }}
 
 [data-testid="stSidebar"] * {{
@@ -127,29 +142,49 @@ html, body, [data-testid="stAppViewContainer"] {{
 }}
 
 [data-testid="stSidebar"] [data-testid="stSidebarNav"] ul {{
-    padding: 0.6rem 0.25rem 1.2rem 0.25rem;
+    padding: 0.75rem 0.4rem 1.4rem 0.4rem;
     display: grid;
-    gap: 0.25rem;
+    gap: 0.35rem;
 }}
 
 [data-testid="stSidebar"] [data-testid="stSidebarNav"] a {{
     display: flex;
     align-items: center;
-    gap: calc(0.75rem * (1 - var(--sidebar-compact)) + 0.35rem);
-    padding: 0.55rem 0.9rem;
-    border-radius: 12px;
-    transition: background-color 0.25s ease, gap 0.2s ease;
+    gap: calc(0.8rem * (1 - var(--sidebar-compact)) + 0.4rem);
+    padding: 0.6rem 1rem;
+    border-radius: 14px;
+    transition: background-color 0.25s ease, gap 0.2s ease, transform 0.25s ease;
     font-weight: 600;
     position: relative;
+    backdrop-filter: blur(2px);
 }}
 
 [data-testid="stSidebar"] [data-testid="stSidebarNav"] a:hover {{
-    background-color: rgba(255, 255, 255, 0.14);
+    background-color: rgba(255, 255, 255, 0.16);
+    transform: translateX(2px);
 }}
 
 [data-testid="stSidebar"] [data-testid="stSidebarNav"] a::before {{
-    font-size: 1.25rem;
-    margin-right: calc(0.35rem * (1 - var(--sidebar-compact)));
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: calc(2.2rem - 0.8rem * var(--sidebar-compact));
+    height: calc(2.2rem - 0.8rem * var(--sidebar-compact));
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.14);
+    border: 1px solid rgba(247, 250, 252, 0.25);
+    margin-right: calc(0.45rem * (1 - var(--sidebar-compact)));
+    font-size: 1.05rem;
+    font-family: "Noto Sans JP", "Noto Sans Symbols", "Hiragino Sans", sans-serif;
+    font-weight: 600;
+    color: #F7FAFC;
+    transition: background-color 0.25s ease, transform 0.25s ease;
+    content: "";
+}}
+
+[data-testid="stSidebar"] [data-testid="stSidebarNav"] a:hover::before {{
+    background: rgba(255, 255, 255, 0.22);
+    transform: translateY(-1px);
 }}
 
 [data-testid="stSidebar"] [data-testid="stSidebarNav"] span {{
@@ -160,27 +195,27 @@ html, body, [data-testid="stAppViewContainer"] {{
 }}
 
 [data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Home"]::before {{
-    content: "🏠";
+    content: "⌂";
 }}
 
 [data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Inputs"]::before {{
-    content: "🧾";
+    content: "✎";
 }}
 
 [data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Analysis"]::before {{
-    content: "📊";
+    content: "▥";
 }}
 
 [data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Scenarios"]::before {{
-    content: "🧮";
+    content: "⧉";
 }}
 
 [data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Report"]::before {{
-    content: "📄";
+    content: "⎘";
 }}
 
 [data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Settings"]::before {{
-    content: "⚙️";
+    content: "⚙";
 }}
 
 [data-testid="stSidebar"] button:focus-visible,
@@ -197,7 +232,7 @@ button:focus-visible {{
 
 .stTabs [role="tablist"] {{
     gap: 0.4rem;
-    border-bottom: 1px solid var(--neutral);
+    border-bottom: 1px solid rgba(15, 44, 79, 0.12);
     flex-wrap: wrap;
 }}
 
@@ -207,34 +242,100 @@ button:focus-visible {{
     border-radius: 14px 14px 0 0;
     background-color: transparent;
     color: var(--text-subtle);
+    border: 1px solid transparent;
 }}
 
 .stTabs [role="tab"][aria-selected="true"] {{
     background-color: var(--surface);
-    color: var(--primary);
-    box-shadow: 0 -2px 20px rgba(31, 78, 121, 0.08);
-    border-bottom: 3px solid var(--accent);
+    color: var(--accent);
+    box-shadow: 0 -2px 24px rgba(15, 44, 79, 0.12);
+    border-color: rgba(15, 44, 79, 0.18);
+    border-bottom: 3px solid var(--primary);
 }}
 
 .hero-card {{
-    background: linear-gradient(135deg, rgba(93, 169, 233, 0.92) 0%, rgba(112, 169, 161, 0.92) 100%);
+    position: relative;
+    overflow: hidden;
+    background: linear-gradient(135deg, rgba(10, 34, 68, 0.96) 0%, rgba(28, 106, 216, 0.92) 100%);
     color: #ffffff;
-    padding: 2.2rem 2.8rem;
-    border-radius: 26px;
-    box-shadow: 0 24px 48px rgba(22, 60, 90, 0.25);
-    margin-bottom: 1.5rem;
+    padding: 2.4rem 3rem;
+    border-radius: 28px;
+    box-shadow: 0 28px 54px rgba(6, 19, 37, 0.32);
+    margin-bottom: 1.75rem;
+}}
+
+.hero-card::before {{
+    content: "";
+    position: absolute;
+    inset: -70px auto auto -90px;
+    width: 240px;
+    height: 240px;
+    background: radial-gradient(circle at 60% 40%, rgba(255, 255, 255, 0.22), transparent 65%);
+    opacity: 0.85;
+}}
+
+.hero-card::after {{
+    content: "";
+    position: absolute;
+    right: -60px;
+    top: -80px;
+    width: 280px;
+    height: 280px;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 280 280'%3E%3Cg fill='none' stroke='%23FFFFFF' stroke-width='6' stroke-linecap='round' stroke-opacity='0.35'%3E%3Ccircle cx='188' cy='86' r='46'/%3E%3Cpath d='M42 212c62-72 142-72 204-144'/%3E%3Cpath d='M64 252c84-52 158-116 216-188'/%3E%3C/g%3E%3C/svg%3E");
+    background-size: contain;
+    background-repeat: no-repeat;
+    opacity: 0.55;
 }}
 
 .hero-card h1 {{
     margin: 0 0 0.6rem 0;
-    font-size: calc(2.1rem * var(--base-font-scale));
+    font-size: calc(2.15rem * var(--base-font-scale));
     font-weight: 700;
 }}
 
 .hero-card p {{
     margin: 0;
-    font-size: calc(1.02rem * var(--base-font-scale));
+    font-size: calc(1.04rem * var(--base-font-scale));
     opacity: 0.92;
+}}
+
+.section-heading {{
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin: 1.6rem 0 1rem;
+}}
+
+.section-heading__icon {{
+    width: 3.1rem;
+    height: 3.1rem;
+    border-radius: 18px;
+    position: relative;
+    background: linear-gradient(135deg, rgba(28, 106, 216, 0.2) 0%, rgba(15, 44, 79, 0.16) 100%);
+    border: 1px solid rgba(15, 44, 79, 0.22);
+    box-shadow: 0 12px 24px rgba(6, 19, 37, 0.12);
+}}
+
+.section-heading__icon::after {{
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Cg fill='none' stroke='%230F2C4F' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round' stroke-opacity='0.7'%3E%3Cpath d='M10 30c4-6 10-6 14-12s6-14 14-14'/%3E%3Cpath d='M8 14c6 0 12 6 12 12s6 10 12 10'/%3E%3C/g%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-size: 72%;
+    background-position: center;
+}}
+
+.section-heading__title {{
+    margin: 0;
+    font-size: calc(1.45rem * var(--base-font-scale));
+}}
+
+.section-heading__subtitle {{
+    margin: 0.2rem 0 0;
+    font-size: calc(0.95rem * var(--base-font-scale));
+    color: var(--text-subtle);
+    font-family: "Noto Sans JP", "Hiragino Sans", "Yu Gothic", sans-serif;
 }}
 
 .responsive-card-grid {{
@@ -245,25 +346,54 @@ button:focus-visible {{
 }}
 
 .metric-card {{
-    background: linear-gradient(145deg, var(--surface) 0%, var(--surface-alt) 100%);
-    border-radius: 20px;
-    padding: 1.2rem 1.4rem;
-    box-shadow: 0 18px 28px rgba(31, 78, 121, 0.08);
+    position: relative;
+    overflow: hidden;
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.94) 0%, rgba(231, 236, 247, 0.9) 100%);
+    border-radius: 22px;
+    padding: 1.3rem 1.55rem;
+    box-shadow: 0 18px 32px rgba(6, 19, 37, 0.1);
     display: flex;
     flex-direction: column;
-    gap: 0.45rem;
+    gap: 0.55rem;
+    border: 1px solid rgba(15, 44, 79, 0.08);
+}}
+
+.metric-card::before {{
+    content: "";
+    position: absolute;
+    left: -50px;
+    bottom: -70px;
+    width: 180px;
+    height: 180px;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 180'%3E%3Cg fill='none' stroke='%230F2C4F' stroke-width='3' stroke-linecap='round' stroke-opacity='0.18'%3E%3Cpath d='M10 130c36-24 74-24 112-70'/%3E%3Cpath d='M22 158c44-26 98-66 148-122'/%3E%3C/g%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-size: cover;
+}}
+
+.metric-card::after {{
+    content: "";
+    position: absolute;
+    top: -60px;
+    right: -40px;
+    width: 150px;
+    height: 150px;
+    background: radial-gradient(circle at center, rgba(28, 106, 216, 0.18), transparent 68%);
+    opacity: 0.9;
 }}
 
 .metric-card--positive {{
-    border: 2px solid var(--positive);
+    border-color: rgba(31, 107, 84, 0.45);
+    box-shadow: 0 18px 34px rgba(31, 107, 84, 0.16);
 }}
 
 .metric-card--caution {{
-    border: 2px solid var(--accent);
+    border-color: rgba(15, 44, 79, 0.35);
+    box-shadow: 0 18px 34px rgba(15, 44, 79, 0.12);
 }}
 
 .metric-card--negative {{
-    border: 2px solid var(--negative);
+    border-color: rgba(138, 53, 66, 0.35);
+    box-shadow: 0 18px 34px rgba(138, 53, 66, 0.12);
 }}
 
 .metric-card__header {{
@@ -275,7 +405,16 @@ button:focus-visible {{
 }}
 
 .metric-card__icon {{
-    font-size: 1.3rem;
+    width: 2.1rem;
+    height: 2.1rem;
+    border-radius: 14px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(28, 106, 216, 0.12);
+    color: var(--accent);
+    font-size: 1.05rem;
+    font-weight: 600;
 }}
 
 .metric-card__label {{
@@ -295,8 +434,9 @@ button:focus-visible {{
     margin-left: 0.5rem;
     padding: 0.1rem 0.5rem;
     border-radius: 999px;
-    background: rgba(31, 78, 121, 0.12);
+    background: rgba(15, 44, 79, 0.08);
     font-size: calc(0.75rem * var(--base-font-scale));
+    color: var(--accent);
 }}
 .metric-card__tone-text {{
     font-weight: 600;
@@ -322,14 +462,27 @@ button:focus-visible {{
 }}
 
 .callout {{
+    position: relative;
+    overflow: hidden;
     display: flex;
-    gap: 0.8rem;
-    padding: 1rem 1.1rem;
-    border-radius: 16px;
-    margin-bottom: 1rem;
-    background-color: var(--surface);
+    gap: 0.9rem;
+    padding: 1.15rem 1.3rem;
+    border-radius: 18px;
+    margin-bottom: 1.2rem;
+    background: linear-gradient(120deg, rgba(255, 255, 255, 0.96) 0%, rgba(231, 236, 247, 0.92) 100%);
     border-left: 6px solid var(--primary);
-    box-shadow: 0 12px 18px rgba(31, 78, 121, 0.08);
+    box-shadow: 0 18px 32px rgba(6, 19, 37, 0.12);
+    border: 1px solid rgba(15, 44, 79, 0.08);
+}}
+
+.callout::after {{
+    content: "";
+    position: absolute;
+    right: -50px;
+    top: -60px;
+    width: 140px;
+    height: 140px;
+    background: radial-gradient(circle at center, rgba(28, 106, 216, 0.16), transparent 70%);
 }}
 
 .callout--positive {{
@@ -341,7 +494,16 @@ button:focus-visible {{
 }}
 
 .callout__icon {{
-    font-size: 1.5rem;
+    width: 2.2rem;
+    height: 2.2rem;
+    border-radius: 14px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(28, 106, 216, 0.12);
+    color: var(--accent);
+    font-size: 1.1rem;
+    font-weight: 600;
 }}
 
 .callout__title {{
@@ -379,10 +541,23 @@ button:focus-visible {{
     border: 0;
 }}
 [data-testid="stMetric"] {{
-    background: linear-gradient(135deg, var(--surface) 0%, var(--surface-alt) 100%);
+    position: relative;
+    overflow: hidden;
+    background: linear-gradient(155deg, rgba(255, 255, 255, 0.95) 0%, rgba(231, 236, 247, 0.9) 100%);
     border-radius: 18px;
-    padding: 1rem 1.2rem;
-    box-shadow: 0 14px 28px rgba(31, 78, 121, 0.08);
+    padding: 1rem 1.25rem;
+    box-shadow: 0 16px 28px rgba(6, 19, 37, 0.1);
+    border: 1px solid rgba(15, 44, 79, 0.08);
+}}
+
+[data-testid="stMetric"]::after {{
+    content: "";
+    position: absolute;
+    top: -40px;
+    right: -30px;
+    width: 110px;
+    height: 110px;
+    background: radial-gradient(circle at center, rgba(28, 106, 216, 0.16), transparent 70%);
 }}
 
 [data-testid="stMetric"] [data-testid="stMetricLabel"] {{
@@ -397,21 +572,25 @@ button:focus-visible {{
 }}
 
 [data-testid="stDataFrame"] {{
-    background-color: var(--surface);
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.98) 0%, rgba(231, 236, 247, 0.92) 100%);
     border-radius: 18px;
-    padding: 0.6rem 0.8rem 0.9rem 0.8rem;
-    box-shadow: 0 12px 26px rgba(31, 78, 121, 0.06);
+    padding: 0.7rem 0.9rem 1rem 0.9rem;
+    box-shadow: 0 16px 28px rgba(6, 19, 37, 0.08);
+    border: 1px solid rgba(15, 44, 79, 0.08);
 }}
 
 button[kind="primary"] {{
-    background-color: var(--primary);
+    background: linear-gradient(135deg, rgba(28, 106, 216, 0.95) 0%, rgba(26, 96, 192, 0.95) 100%);
     border-radius: 999px;
-    border: none;
-    box-shadow: 0 10px 20px rgba(31, 78, 121, 0.15);
+    border: 1px solid rgba(15, 44, 79, 0.18);
+    box-shadow: 0 18px 30px rgba(28, 106, 216, 0.25);
+    color: #FFFFFF;
+    letter-spacing: 0.02em;
+    font-weight: 600;
 }}
 
 button[kind="primary"]:hover {{
-    background-color: var(--primary-light);
+    background: linear-gradient(135deg, rgba(66, 140, 229, 0.98) 0%, rgba(52, 124, 214, 0.98) 100%);
 }}
 
 button[kind="primary"]:focus-visible {{
@@ -420,16 +599,16 @@ button[kind="primary"]:focus-visible {{
 }}
 
 .field-error {{
-    border: 1px solid var(--negative);
-    border-radius: 12px;
-    padding: 0.8rem;
-    background-color: rgba(248, 113, 113, 0.15);
+    border: 1px solid rgba(138, 53, 66, 0.5);
+    border-radius: 14px;
+    padding: 0.85rem;
+    background-color: rgba(138, 53, 66, 0.1);
     color: var(--negative);
 }}
 
 @media (max-width: 980px) {{
     .hero-card {{
-        padding: 1.6rem 1.8rem;
+        padding: 1.9rem 2rem;
     }}
     .responsive-card-grid {{
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
@@ -440,6 +619,13 @@ button[kind="primary"]:focus-visible {{
 }}
 
 @media (max-width: 640px) {{
+    .section-heading {{
+        align-items: flex-start;
+    }}
+    .section-heading__icon {{
+        width: 2.6rem;
+        height: 2.6rem;
+    }}
     .hero-card h1 {{
         font-size: calc(1.6rem * var(--base-font-scale));
     }}
@@ -450,7 +636,7 @@ button[kind="primary"]:focus-visible {{
         padding: 0.6rem 0.9rem;
     }}
     .metric-card {{
-        padding: 1rem 1.1rem;
+        padding: 1.05rem 1.15rem;
     }}
     .responsive-card-grid {{
         grid-template-columns: 1fr;

--- a/ui/chrome.py
+++ b/ui/chrome.py
@@ -108,7 +108,7 @@ def render_app_header(
         with account_col:
             current_user = auth.get_current_user()
             account_label = (
-                f"🔐 {current_user.display_name}" if current_user else "🔑 ログイン"
+                f"▣ {current_user.display_name}" if current_user else "⎔ ログイン"
             )
             with st.popover(account_label, help="保存やバージョン管理を行うにはログインしてください。"):
                 if current_user:
@@ -118,7 +118,7 @@ def render_app_header(
                     st.caption("役割: " + ("管理者" if current_user.role == "admin" else "メンバー"))
                     if st.button("ログアウト", key="header_logout_button", help="セキュアにセッションを終了します。"):
                         auth.logout_user()
-                        st.toast("ログアウトしました。", icon="👋")
+                        st.toast("ログアウトしました。", icon="◇")
                         logout_requested = True
                         st.experimental_rerun()
                 else:

--- a/ui/components.py
+++ b/ui/components.py
@@ -22,9 +22,9 @@ class MetricCard:
 
 
 _TONE_BADGES: dict[str, tuple[str, str]] = {
-    "positive": ("🟢", "好調"),
-    "caution": ("⚠️", "注意"),
-    "negative": ("🔴", "警戒"),
+    "positive": ("▲", "好調"),
+    "caution": ("△", "注意"),
+    "negative": ("▼", "警戒"),
 }
 
 

--- a/views/home.py
+++ b/views/home.py
@@ -59,7 +59,18 @@ def render_home_page() -> None:
     summary_tab, tutorial_tab = st.tabs(["概要", "チュートリアル"])
 
     with summary_tab:
-        st.subheader("📌 現状サマリー")
+        st.markdown(
+            """
+            <div class=\"section-heading\" role=\"presentation\">
+                <div class=\"section-heading__icon\" aria-hidden=\"true\"></div>
+                <div>
+                    <h2 class=\"section-heading__title\">現状サマリー</h2>
+                    <p class=\"section-heading__subtitle\">最新の主要KPIで現状を俯瞰</p>
+                </div>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
 
         if not has_custom_inputs:
             st.info("入力ページでデータを保存すると、ここに最新のKPIが表示されます。")
@@ -78,7 +89,7 @@ def render_home_page() -> None:
 
     metric_cards = [
         MetricCard(
-            icon="💴",
+            icon="¥",
             label="売上高",
             value=format_amount_with_unit(amounts.get("REV", Decimal("0")), unit),
             description="チャネル×商品×月の年間売上合計",
@@ -86,16 +97,16 @@ def render_home_page() -> None:
             assistive_text="売上高のカード。チャネル×商品×月の年間売上合計です。",
         ),
         MetricCard(
-            icon="📈",
+            icon="↗",
             label="粗利率",
             value=format_ratio(metrics.get("gross_margin")),
             description="粗利÷売上で算出される利益率",
             aria_label="粗利率",
             tone="positive" if (metrics.get("gross_margin") or Decimal("0")) >= Decimal("0.3") else "neutral",
-            assistive_text="粗利率のカード。数値が高いほど利益体質が良好で、色とアイコンで状況を示しています。",
+            assistive_text="粗利率のカード。数値が高いほど利益体質が良好で、トーンバッジで状況を示しています。",
         ),
         MetricCard(
-            icon="🏦",
+            icon="Σ",
             label="経常利益",
             value=format_amount_with_unit(amounts.get("ORD", Decimal("0")), unit),
             description="営業外収支も含めた利益水準",
@@ -103,13 +114,13 @@ def render_home_page() -> None:
             assistive_text="経常利益のカード。営業外収支を含めた年間の利益水準です。",
         ),
         MetricCard(
-            icon="🎯",
+            icon="⚑",
             label="損益分岐点売上高",
             value=format_amount_with_unit(metrics.get("breakeven"), unit),
             description="固定費を回収するために必要な売上高",
             aria_label="損益分岐点の売上高",
             tone="caution",
-            assistive_text="損益分岐点売上高のカード。⚠️バッジで注意が必要なことを示します。",
+            assistive_text="損益分岐点売上高のカード。△バッジで注意が必要なことを示します。",
         ),
     ]
     render_metric_cards(metric_cards, grid_aria_label="主要指標サマリー")
@@ -118,14 +129,25 @@ def render_home_page() -> None:
 
     if not auth.is_authenticated():
         render_callout(
-            icon="🔐",
+            icon="▣",
             title="ログインするとクラウド保存とバージョン管理が利用できます",
             body="ヘッダー右上のログインからアカウントを作成すると、入力データをクラウドに保存し、シナリオ別にバージョン管理できます。",
             tone="caution",
             aria_label="ログインを促す案内",
         )
 
-    st.markdown("### 次のステップ")
+    st.markdown(
+        """
+        <div class=\"section-heading\" role=\"presentation\">
+            <div class=\"section-heading__icon\" aria-hidden=\"true\"></div>
+            <div>
+                <h2 class=\"section-heading__title\">次のステップ</h2>
+                <p class=\"section-heading__subtitle\">ライトブルーの導線で操作手順を整理</p>
+            </div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
     st.markdown(
         """
         1. **Inputs** ページで売上・原価・費用・投資・借入・税制を登録する
@@ -137,7 +159,18 @@ def render_home_page() -> None:
     )
 
     with tutorial_tab:
-        st.subheader("🧭 チュートリアル")
+        st.markdown(
+            """
+            <div class=\"section-heading\" role=\"presentation\">
+                <div class=\"section-heading__icon\" aria-hidden=\"true\"></div>
+                <div>
+                    <h2 class=\"section-heading__title\">チュートリアル</h2>
+                    <p class=\"section-heading__subtitle\">主要な操作ポイントを簡潔に整理</p>
+                </div>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
         st.markdown(
             """
             - **セッションの保持**: サイドバーのページ遷移でも入力値はセッションステートに保存されます。


### PR DESCRIPTION
## Summary
- refresh the shared Streamlit theme with a restrained blue palette, serif headings, and updated gradients for hero cards, metrics, callouts, and buttons
- replace emoji-based iconography with monochrome symbols and section heading illustrations across the home dashboard and downstream pages
- update page configurations, toast messages, and download labels to align with the simplified visual language

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d32ac4fb808323904417078372657f