### PR TITLE
Fix Streamlit toast icon to use supported emoji

### DIFF
--- a/pages/10_Inputs.py
+++ b/pages/10_Inputs.py
@@ -736,7 +736,7 @@ def _maybe_show_tutorial(step_id: str, message: str) -> None:
         shown = set()
     if step_id in shown:
         return
-    st.toast(message, icon="✦")
+    st.toast(message, icon="✨")
     shown.add(step_id)
     st.session_state["tutorial_shown_steps"] = shown
 


### PR DESCRIPTION
## Summary
- replace the tutorial toast icon with a Streamlit-supported emoji to avoid runtime errors

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d330c44a308323aaa95e07f3a86336