### PR TITLE
Fix popover compatibility for older Streamlit versions

### DIFF
--- a/pages/10_Inputs.py
+++ b/pages/10_Inputs.py
@@ -266,7 +266,8 @@ def _render_field_guide_popover(
     """Render a popover button that exposes examples and best practices."""
 
     glossary_url = f"{GLOSSARY_URL}#{glossary_anchor}" if glossary_anchor else GLOSSARY_URL
-    with st.popover(f"📘 {title}", key=key, use_container_width=True):
+    popover_kwargs = use_container_width_kwargs(st.popover)
+    with st.popover(f"📘 {title}", key=key, **popover_kwargs):
         if example:
             st.markdown("**記入例**")
             st.markdown(example)


### PR DESCRIPTION
## Summary
- ensure the field guide popovers only pass `use_container_width` when the current Streamlit version supports it

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d3f81b9c988323935e16e2621f4cb0