### PR TITLE
Fix segmented control default argument

### DIFF
--- a/views/home.py
+++ b/views/home.py
@@ -445,7 +445,7 @@ def render_home_page() -> None:
     active_label = st.segmented_control(
         "指標タブ",
         TAB_LABELS,
-        selection=previous_label,
+        default=previous_label,
         key="primary_tab_selector",
         label_visibility="collapsed",
     )


### PR DESCRIPTION
## Summary
- update the Streamlit segmented control to use the supported `default` argument when restoring the previous tab selection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d51ca0585c8323aaa4c407220b76e4