### PR TITLE
Add guided navigation and workflow banner

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 
 import streamlit as st
 
+from state import ensure_session_defaults
+from theme import inject_theme
+from ui.navigation import render_global_navigation, render_workflow_banner
 from views import render_home_page
 
 st.set_page_config(
@@ -11,4 +14,8 @@ st.set_page_config(
     layout="wide",
 )
 
+inject_theme()
+ensure_session_defaults()
+render_global_navigation("home")
+render_workflow_banner("home")
 render_home_page()

--- a/pages/00_Home.py
+++ b/pages/00_Home.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 
 import streamlit as st
 
+from state import ensure_session_defaults
+from theme import inject_theme
+from ui.navigation import render_global_navigation, render_workflow_banner
 from views import render_home_page
 
 st.set_page_config(
@@ -11,4 +14,8 @@ st.set_page_config(
     layout="wide",
 )
 
+inject_theme()
+ensure_session_defaults()
+render_global_navigation("home")
+render_workflow_banner("home")
 render_home_page()

--- a/pages/10_Inputs.py
+++ b/pages/10_Inputs.py
@@ -44,6 +44,7 @@ from services.marketing_strategy import (
     marketing_state_has_content,
 )
 from theme import inject_theme
+from ui.navigation import render_global_navigation, render_workflow_banner
 from ui.components import render_callout
 from validators import ValidationIssue, validate_bundle
 from ui.streamlit_compat import use_container_width_kwargs
@@ -57,6 +58,9 @@ st.set_page_config(
 
 inject_theme()
 ensure_session_defaults()
+
+render_global_navigation("inputs")
+render_workflow_banner("inputs")
 
 finance_raw: Dict[str, Dict] = st.session_state.get("finance_raw", {})
 if not finance_raw:

--- a/pages/20_Analysis.py
+++ b/pages/20_Analysis.py
@@ -29,6 +29,7 @@ from models import (
     DEFAULT_TAX_POLICY,
 )
 from theme import COLOR_BLIND_COLORS, THEME_COLORS, inject_theme
+from ui.navigation import render_global_navigation, render_workflow_banner
 from ui.components import MetricCard, render_metric_cards
 from ui.streamlit_compat import use_container_width_kwargs
 from services.marketing_strategy import (
@@ -1170,6 +1171,9 @@ st.set_page_config(
 
 inject_theme()
 ensure_session_defaults()
+
+render_global_navigation("analysis")
+render_workflow_banner("analysis")
 
 settings_state: Dict[str, object] = st.session_state.get("finance_settings", {})
 unit = str(settings_state.get("unit", "百万円"))

--- a/pages/30_Scenarios.py
+++ b/pages/30_Scenarios.py
@@ -16,6 +16,7 @@ from formatting import format_amount_with_unit, format_delta
 from models import CapexPlan, LoanSchedule, TaxPolicy
 from state import ensure_session_defaults, load_finance_bundle
 from theme import inject_theme
+from ui.navigation import render_global_navigation, render_workflow_banner
 from ui.streamlit_compat import use_container_width_kwargs
 
 st.set_page_config(
@@ -26,6 +27,9 @@ st.set_page_config(
 
 inject_theme()
 ensure_session_defaults()
+
+render_global_navigation("scenarios")
+render_workflow_banner("scenarios")
 
 DRIVER_LABELS: Dict[str, str] = {
     "customers": "客数",

--- a/pages/40_Report.py
+++ b/pages/40_Report.py
@@ -35,6 +35,7 @@ from calc import compute, generate_cash_flow, plan_from_models, summarize_plan_m
 from formatting import format_amount_with_unit, format_ratio
 from state import ensure_session_defaults, load_finance_bundle
 from theme import THEME_COLORS, inject_theme
+from ui.navigation import render_global_navigation, render_workflow_banner
 
 st.set_page_config(
     page_title="経営計画スタジオ｜レポート",
@@ -44,6 +45,9 @@ st.set_page_config(
 
 inject_theme()
 ensure_session_defaults()
+
+render_global_navigation("report")
+render_workflow_banner("report")
 
 settings_state: Dict[str, object] = st.session_state.get("finance_settings", {})
 unit = str(settings_state.get("unit", "百万円"))

--- a/pages/90_Settings.py
+++ b/pages/90_Settings.py
@@ -15,6 +15,7 @@ from models import (
 )
 from state import ensure_session_defaults
 from theme import inject_theme
+from ui.navigation import render_global_navigation, render_workflow_banner
 from services import auth
 from ui.streamlit_compat import use_container_width_kwargs
 
@@ -26,6 +27,9 @@ st.set_page_config(
 
 inject_theme()
 ensure_session_defaults()
+
+render_global_navigation("settings")
+render_workflow_banner("settings")
 
 settings_state: Dict[str, object] = st.session_state.get("finance_settings", {})
 unit = str(settings_state.get("unit", "百万円"))

--- a/theme.py
+++ b/theme.py
@@ -164,130 +164,182 @@ h6, .stMarkdown h6 {{ font-size: calc(0.9rem * var(--base-font-scale)); }}
     color: #F5F7FA !important;
 }}
 
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] ul {{
-    padding: 16px 8px 24px 8px;
-    display: grid;
-    gap: 8px;
+[data-testid="stSidebar"] [data-testid="stSidebarNav"] {{
+    display: none !important;
 }}
 
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a {{
+.sidebar-nav__header {{
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    opacity: 0.85;
+    margin: 1rem 0 0.6rem 0;
+}}
+
+.sidebar-nav {{
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}}
+
+[data-testid="stSidebar"] button[kind="secondary"] {{
     display: flex;
     align-items: center;
-    gap: calc(0.6rem * (1 - var(--sidebar-compact)) + 0.4rem);
-    padding: 12px 16px;
+    justify-content: flex-start;
+    gap: 0.6rem;
+    padding: 0.75rem 0.9rem;
     border-radius: var(--radius-md);
-    transition: background-color 0.25s ease, gap 0.2s ease, transform 0.25s ease;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    background: rgba(255, 255, 255, 0.08);
+    color: #F5F7FA;
     font-weight: 600;
-    position: relative;
-    background: rgba(255, 255, 255, 0.06);
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    transition: background 0.25s ease, transform 0.25s ease;
 }}
 
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a:hover {{
-    background: rgba(255, 255, 255, 0.12);
+[data-testid="stSidebar"] button[kind="secondary"]:hover:not(:disabled) {{
+    background: rgba(255, 255, 255, 0.14);
     transform: translateX(2px);
 }}
 
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a[aria-current="page"] {{
-    background: rgba(255, 255, 255, 0.18);
-    border-color: rgba(255, 255, 255, 0.3);
+[data-testid="stSidebar"] button[kind="primary"] {{
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 0.7rem;
+    padding: 0.85rem 1rem;
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(255, 255, 255, 0.45);
+    background: rgba(255, 255, 255, 0.24);
+    color: #0B1F3B;
+    font-weight: 700;
+    box-shadow: 0 12px 28px rgba(255, 255, 255, 0.18);
 }}
 
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a::before {{
+[data-testid="stSidebar"] button[kind="primary"]:disabled {{
+    color: #0B1F3B;
+}}
+
+[data-testid="stSidebar"] button[kind="secondary"] span,
+[data-testid="stSidebar"] button[kind="primary"] span {{
+    font-size: 1rem;
+    letter-spacing: 0.01em;
+}}
+
+.workflow-banner {{
+    position: sticky;
+    top: 0;
+    z-index: 120;
+    background: var(--surface);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-subtle);
+    padding: 1.1rem 1.25rem;
+    margin: -1rem -0.2rem 1.5rem -0.2rem;
+    border: 1px solid var(--border-color);
+}}
+
+.workflow-banner__title {{
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    color: var(--primary);
+    font-size: 1.05rem;
+}}
+
+.workflow-banner__list {{
+    list-style: none;
+    display: flex;
+    gap: 0.9rem;
+    margin: 0.85rem 0 0.5rem 0;
+    padding: 0;
+    overflow-x: auto;
+}}
+
+.workflow-banner__item {{
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    min-width: 210px;
+    padding: 0.55rem 0.85rem;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border-color);
+    background: var(--surface-alt);
+    transition: border 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}}
+
+.workflow-banner__badge {{
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: calc(2rem - 0.7rem * var(--sidebar-compact));
-    height: calc(2rem - 0.7rem * var(--sidebar-compact));
-    border-radius: 12px;
-    background: rgba(255, 255, 255, 0.14);
-    margin-right: calc(0.35rem * (1 - var(--sidebar-compact)));
-    font-size: 1.05rem;
+    width: 2.1rem;
+    height: 2.1rem;
+    border-radius: 999px;
+    background: rgba(30, 136, 229, 0.14);
+    color: var(--accent);
+    font-weight: 700;
+    font-size: 0.95rem;
+}}
+
+.workflow-banner__label {{
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}}
+
+.workflow-banner__label-text {{
     font-weight: 600;
-    content: "";
+    color: var(--primary);
 }}
 
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a:hover::before {{
-    background: rgba(255, 255, 255, 0.22);
+.workflow-banner__description {{
+    font-size: 0.85rem;
+    color: var(--text-subtle);
+    line-height: 1.35;
 }}
 
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] span {{
-    opacity: calc(1 - 0.9 * var(--sidebar-compact));
-    transition: opacity 0.25s ease;
-    white-space: nowrap;
-    pointer-events: none;
+.workflow-banner__item--completed {{
+    background: rgba(60, 122, 94, 0.12);
+    border-color: rgba(60, 122, 94, 0.28);
 }}
 
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Home"]::before {{
-    content: "⌂";
+.workflow-banner__item--completed .workflow-banner__badge {{
+    background: var(--positive);
+    color: #ffffff;
 }}
 
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Inputs"]::before {{
-    content: "✎";
+.workflow-banner__item--current {{
+    background: rgba(30, 136, 229, 0.18);
+    border-color: rgba(30, 136, 229, 0.45);
+    box-shadow: 0 14px 32px rgba(30, 136, 229, 0.25);
 }}
 
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Analysis"]::before {{
-    content: "▥";
+.workflow-banner__item--current .workflow-banner__badge {{
+    background: var(--accent);
+    color: #ffffff;
 }}
 
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Scenarios"]::before {{
-    content: "⧉";
+.workflow-banner__item--upcoming {{
+    opacity: 0.9;
 }}
 
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Report"]::before {{
-    content: "⎘";
+.workflow-banner__meta {{
+    font-size: 0.85rem;
+    color: var(--text-subtle);
 }}
 
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Settings"]::before {{
-    content: "⚙";
+.sticky-tab-bar {{
+    position: sticky;
+    top: 136px;
+    z-index: 90;
+    background: var(--surface);
+    padding: 0.7rem 1rem 0.5rem;
+    margin: 0 -0.2rem 1.25rem -0.2rem;
+    border-bottom: 1px solid var(--border-color);
+    box-shadow: 0 18px 30px rgba(11, 31, 59, 0.08);
 }}
 
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] li:first-child a::before {{
-    content: "⌂";
-}}
-
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] li:first-child a span,
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Home"] span,
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Inputs"] span,
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Analysis"] span,
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Scenarios"] span,
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Report"] span,
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Settings"] span {{
-    font-size: 0;
-}}
-
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a span::after {{
-    font-size: calc(1rem - 0.2rem * var(--sidebar-compact));
-    color: #F5F7FA;
-    letter-spacing: 0.02em;
-}}
-
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] li:first-child a span::after {{
-    content: "ホーム";
-}}
-
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Home"] span::after {{
-    content: "概要";
-}}
-
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Inputs"] span::after {{
-    content: "入力";
-}}
-
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Analysis"] span::after {{
-    content: "分析";
-}}
-
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Scenarios"] span::after {{
-    content: "シナリオ";
-}}
-
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Report"] span::after {{
-    content: "レポート";
-}}
-
-[data-testid="stSidebar"] [data-testid="stSidebarNav"] a[href*="Settings"] span::after {{
-    content: "設定";
+.sticky-tab-bar [role="radiogroup"] {{
+    justify-content: center;
+    gap: 0.6rem;
 }}
 
 [data-testid="stSidebar"] button:focus-visible,

--- a/ui/navigation.py
+++ b/ui/navigation.py
@@ -1,0 +1,176 @@
+"""Custom global navigation and workflow banner components."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import streamlit as st
+
+
+@dataclass(frozen=True)
+class NavigationItem:
+    """Metadata for a sidebar navigation entry."""
+
+    key: str
+    label: str
+    icon: str
+    description: str
+    page_path: str | None
+    step_label: str
+    include_in_flow: bool = True
+
+
+NAVIGATION_ITEMS: tuple[NavigationItem, ...] = (
+    NavigationItem(
+        key="home",
+        label="ホーム",
+        icon="🏠",
+        description="主要KPIとインサイトを確認するダッシュボードへ移動します。",
+        page_path="pages/00_Home.py",
+        step_label="①ホーム",
+        include_in_flow=False,
+    ),
+    NavigationItem(
+        key="inputs",
+        label="入力",
+        icon="📝",
+        description="3C分析やビジネスモデルキャンバスなどの前提条件を入力します。",
+        page_path="pages/10_Inputs.py",
+        step_label="②データ入力",
+    ),
+    NavigationItem(
+        key="analysis",
+        label="分析",
+        icon="📊",
+        description="KPIダッシュボードや損益分岐・キャッシュフロー分析を実行します。",
+        page_path="pages/20_Analysis.py",
+        step_label="③分析",
+    ),
+    NavigationItem(
+        key="scenarios",
+        label="シナリオ",
+        icon="🔀",
+        description="ベースライン/ベスト/ワーストを比較し、VaRやDSCR閾値を確認します。",
+        page_path="pages/30_Scenarios.py",
+        step_label="④シナリオ",
+    ),
+    NavigationItem(
+        key="report",
+        label="レポート",
+        icon="📄",
+        description="McKinsey風テンプレートでPDF・PPTX・Excel・Wordへ出力します。",
+        page_path="pages/40_Report.py",
+        step_label="⑤レポート",
+    ),
+    NavigationItem(
+        key="settings",
+        label="設定",
+        icon="⚙️",
+        description="単位・会計期間・バックアップ設定を編集します。",
+        page_path="pages/90_Settings.py",
+        step_label="設定",
+        include_in_flow=False,
+    ),
+)
+
+
+WORKFLOW_ITEMS: tuple[NavigationItem, ...] = tuple(
+    item for item in NAVIGATION_ITEMS if item.include_in_flow
+)
+
+
+def _switch_to(page_path: str | None) -> None:
+    """Navigate to the given multipage *page_path* if provided."""
+
+    if not page_path:
+        return
+    st.switch_page(page_path)
+
+
+def render_global_navigation(current_key: str) -> None:
+    """Render labelled sidebar navigation with icon buttons and tooltips."""
+
+    st.sidebar.markdown(
+        "<div class='sidebar-nav__header'>ワークフローナビゲーション</div>",
+        unsafe_allow_html=True,
+    )
+
+    nav_container = st.sidebar.container()
+    with nav_container:
+        st.markdown("<div class='sidebar-nav' role='navigation'>", unsafe_allow_html=True)
+        for item in NAVIGATION_ITEMS:
+            is_active = item.key == current_key
+            if is_active:
+                st.session_state["sidebar_step"] = item.step_label
+            clicked = st.button(
+                f"{item.icon} {item.label}",
+                key=f"nav_button_{item.key}",
+                help=item.description,
+                use_container_width=True,
+                type="primary" if is_active else "secondary",
+                disabled=is_active,
+            )
+            if clicked and not is_active:
+                st.session_state["sidebar_step"] = item.step_label
+                _switch_to(item.page_path)
+        st.markdown("</div>", unsafe_allow_html=True)
+
+    st.sidebar.caption("入力→分析→シナリオ→レポートの順に進めると迷わず作業できます。")
+
+
+def render_workflow_banner(current_key: str) -> None:
+    """Render a sticky top workflow banner indicating the current phase."""
+
+    if not WORKFLOW_ITEMS:
+        return
+
+    current_index = next(
+        (idx for idx, item in enumerate(WORKFLOW_ITEMS) if item.key == current_key),
+        None,
+    )
+    if current_index is None:
+        current_index = 0 if current_key == "home" else len(WORKFLOW_ITEMS) - 1
+
+    fragments: list[str] = []
+    for idx, item in enumerate(WORKFLOW_ITEMS):
+        status = "completed" if idx < current_index else "upcoming"
+        if idx == current_index:
+            status = "current"
+        aria_current = " aria-current=\"step\"" if status == "current" else ""
+        fragments.append(
+            """
+            <li class='workflow-banner__item workflow-banner__item--{status}'{aria_current}>
+              <span class='workflow-banner__badge'>{badge}</span>
+              <div class='workflow-banner__label'>
+                <span class='workflow-banner__label-text'>{icon} {label}</span>
+                <span class='workflow-banner__description'>{desc}</span>
+              </div>
+            </li>
+            """.format(
+                status=status,
+                aria_current=aria_current,
+                badge=f"{idx + 1:02d}",
+                icon=item.icon,
+                label=item.label,
+                desc=item.description,
+            )
+        )
+
+    if current_key == "home":
+        next_step_text = WORKFLOW_ITEMS[0].label
+    elif current_index >= len(WORKFLOW_ITEMS) - 1:
+        next_step_text = "完了です"
+    else:
+        next_step_text = WORKFLOW_ITEMS[current_index + 1].label
+
+    st.markdown(
+        """
+        <section class='workflow-banner' aria-label='ユーザージャーニー'>
+          <header class='workflow-banner__title'>入力からレポートまでの進行状況</header>
+          <ol class='workflow-banner__list'>
+            {items}
+          </ol>
+          <div class='workflow-banner__meta'>次のステップ: {next_step}</div>
+        </section>
+        """.format(items="".join(fragments), next_step=next_step_text),
+        unsafe_allow_html=True,
+    )
+

--- a/views/home.py
+++ b/views/home.py
@@ -563,6 +563,7 @@ def _render_tab_selector() -> str:
         _log_event("switch_tab", tab=current)
         _sync_query_params(tab=current)
 
+    st.markdown("<div class='sticky-tab-bar'>", unsafe_allow_html=True)
     selected = st.radio(
         "表示タブ",
         TAB_LABELS,
@@ -572,6 +573,7 @@ def _render_tab_selector() -> str:
         horizontal=True,
         label_visibility="collapsed",
     )
+    st.markdown("</div>", unsafe_allow_html=True)
     return selected
 
 
@@ -611,11 +613,11 @@ def _render_home_summary(ctx: DashboardContext) -> None:
     st.markdown('<div class="dashboard-kpi-row">', unsafe_allow_html=True)
     k1, k2, k3 = st.columns(3)
     with k1:
-        st.metric("売上対予実差[%]", "+4.2pt", "+0.8pt", delta_color="normal")
+        st.metric("📈 売上対予実差[%]", "+4.2pt", "+0.8pt", delta_color="normal")
     with k2:
-        st.metric("粗利率[%]", "32.1%", "-0.8pt", delta_color="inverse")
+        st.metric("💹 粗利率[%]", "32.1%", "-0.8pt", delta_color="inverse")
     with k3:
-        st.metric("資金残高[千円]", "12,300千円", "+320千円", delta_color="normal")
+        st.metric("💰 資金残高[千円]", "12,300千円", "+320千円", delta_color="normal")
     st.markdown("</div>", unsafe_allow_html=True)
     st.caption(f"{ctx.period} / {ctx.store} / {ctx.grain} で集計")
     st.markdown(


### PR DESCRIPTION
## Summary
- replace the default sidebar with labelled icon buttons that switch pages and show workflow tips
- introduce a sticky workflow banner so users can track the Input → Analysis → Scenario → Report journey across pages
- refresh the home dashboard with sticky KPI tabs and richer card styling tweaks for better readability

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5373a9c8883239a191c02a2e65806