### PR TITLE
Add Streamlit rerun compatibility helper

### DIFF
--- a/pages/10_Inputs.py
+++ b/pages/10_Inputs.py
@@ -48,7 +48,7 @@ from theme import inject_theme
 from ui.navigation import render_global_navigation, render_workflow_banner
 from ui.components import render_callout
 from validators import ValidationIssue, validate_bundle
-from ui.streamlit_compat import use_container_width_kwargs
+from ui.streamlit_compat import rerun, use_container_width_kwargs
 from ui.fermi import FERMI_SEASONAL_PATTERNS, compute_fermi_estimate
 
 st.set_page_config(
@@ -1706,7 +1706,7 @@ def _render_fermi_wizard(sales_df: pd.DataFrame, unit: str) -> None:
                 updated_df = _apply_fermi_result(sales_df)
                 st.session_state[SALES_TEMPLATE_STATE_KEY] = updated_df
                 st.toast("Fermi推定を売上テンプレートに反映しました。", icon="✔")
-                st.experimental_rerun()
+                rerun()
 
         if history:
             st.caption(f"過去{len(history)}件の実績学習に基づく中央値補正係数: x{avg_ratio:.2f}")
@@ -2916,7 +2916,7 @@ if current_step == "context":
             st.session_state.pop(AI_CONTEXT_MESSAGE_KEY, None)
             st.session_state.pop(AI_CONTEXT_HIGHLIGHTS_KEY, None)
             st.toast("AI提案メモをクリアしました。", icon="🧹")
-            st.experimental_rerun()
+            rerun()
 
         if generate_clicked:
             try:
@@ -2943,7 +2943,7 @@ if current_step == "context":
                     "text": f"{suggestion.profile_name}向けの草案を挿入しました（文体：{suggestion.tone_label}）。",
                 }
                 st.session_state[AI_CONTEXT_HIGHLIGHTS_KEY] = suggestion.highlights
-            st.experimental_rerun()
+            rerun()
 
         st.caption("※ 生成結果は自動保存されるため、各入力欄で必要に応じて加筆・修正してください。")
 
@@ -4873,7 +4873,7 @@ elif current_step == "tax":
                                 f"{selected_plan.name} v{selected_version.version} を読み込みました。",
                                 icon="✔",
                             )
-                            st.experimental_rerun()
+                            rerun()
                 else:
                     st.info("選択した計画にはバージョンがまだありません。")
 

--- a/pages/30_Scenarios.py
+++ b/pages/30_Scenarios.py
@@ -19,7 +19,7 @@ from models import CapexPlan, LoanSchedule, TaxPolicy
 from state import ensure_session_defaults, load_finance_bundle
 from theme import inject_theme
 from ui.navigation import render_global_navigation, render_workflow_banner
-from ui.streamlit_compat import use_container_width_kwargs
+from ui.streamlit_compat import rerun, use_container_width_kwargs
 
 st.set_page_config(
     page_title="経営計画スタジオ｜シナリオ",
@@ -327,21 +327,21 @@ def _render_scenario_cards(df: pd.DataFrame) -> pd.DataFrame:
         if move_up:
             updated_df = _move_scenario_row(updated_df, index, -1)
             st.session_state["scenario_df"] = _sanitize_scenario_df(updated_df)
-            st.experimental_rerun()
+            rerun()
         if move_down:
             updated_df = _move_scenario_row(updated_df, index, 1)
             st.session_state["scenario_df"] = _sanitize_scenario_df(updated_df)
-            st.experimental_rerun()
+            rerun()
         if duplicate:
             updated_df = _duplicate_scenario_row(updated_df, index)
             st.session_state["scenario_df"] = _sanitize_scenario_df(updated_df)
-            st.experimental_rerun()
+            rerun()
         if delete:
             updated_df = updated_df.drop(updated_df.index[index]).reset_index(drop=True)
             if updated_df.empty:
                 updated_df = _default_scenario_dataframe()
             st.session_state["scenario_df"] = _sanitize_scenario_df(updated_df)
-            st.experimental_rerun()
+            rerun()
 
         note = str(record.get("notes", "")).strip() or "メモは未入力です。"
         st.write(note)

--- a/ui/chrome.py
+++ b/ui/chrome.py
@@ -8,7 +8,7 @@ import html
 import streamlit as st
 from services import auth
 from services.auth import AuthError
-from ui.streamlit_compat import use_container_width_kwargs
+from ui.streamlit_compat import rerun, use_container_width_kwargs
 
 USAGE_GUIDE_TEXT = (
     "1. **入力を整える**: コントロールハブで売上・コストのレバーと会計年度、FTEを設定します。\n"
@@ -121,7 +121,7 @@ def render_app_header(
                         auth.logout_user()
                         st.toast("ログアウトしました。", icon="◇")
                         logout_requested = True
-                        st.experimental_rerun()
+                        rerun()
                 else:
                     login_tab, register_tab = st.tabs(["ログイン", "新規登録"])
                     with login_tab:
@@ -140,7 +140,7 @@ def render_app_header(
                                 try:
                                     auth.login_user(login_email, login_password)
                                     st.success("ログインしました。ページを更新します。")
-                                    st.experimental_rerun()
+                                    rerun()
                                 except AuthError as exc:
                                     st.error(str(exc))
                     with register_tab:
@@ -170,7 +170,7 @@ def render_app_header(
                                     )
                                     auth.login_via_token(user)
                                     st.success("アカウントを作成しました。ページを更新します。")
-                                    st.experimental_rerun()
+                                    rerun()
                                 except AuthError as exc:
                                     st.error(str(exc))
         if show_reset:

--- a/ui/streamlit_compat.py
+++ b/ui/streamlit_compat.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import inspect
 from typing import Any, Callable, Dict
 
+import streamlit as st
+
 ComponentCallable = Callable[..., Any]
 
 _ACCEPTS_CACHE: Dict[int, bool] = {}
@@ -60,4 +62,13 @@ def use_container_width_kwargs(
     return {}
 
 
-__all__ = ["use_container_width_kwargs"]
+def rerun() -> None:
+    """Trigger a rerun across supported Streamlit versions."""
+
+    if hasattr(st, "rerun"):
+        st.rerun()
+    else:  # pragma: no cover - legacy fallback
+        st.experimental_rerun()
+
+
+__all__ = ["use_container_width_kwargs", "rerun"]


### PR DESCRIPTION
## Summary
- add a rerun helper in `ui/streamlit_compat` that supports both `st.rerun` and the legacy API
- update pages and shared chrome to use the compatibility helper instead of `st.experimental_rerun`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d54f44a24c8323a39f6078347a9bae